### PR TITLE
Center the item inside the carousel’s button

### DIFF
--- a/sly/style.css
+++ b/sly/style.css
@@ -148,6 +148,9 @@ main {
 }
 
 #carousel > button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     min-width: 50px;
     min-height: 50px;
     border-radius: 50%;


### PR DESCRIPTION
Before:

![sly-before](https://github.com/user-attachments/assets/7c675119-7f45-4811-809d-cd57883ba1d2)

After:

![sly-after](https://github.com/user-attachments/assets/d6268cc5-da8f-4ca4-84d4-599f71a4dc90)

Close up:

https://github.com/user-attachments/assets/8a4c5497-2410-4393-aca5-30fd3a03c7aa



